### PR TITLE
Add support for unordered arrays

### DIFF
--- a/addon/mixins/form-object.js
+++ b/addon/mixins/form-object.js
@@ -153,7 +153,8 @@ export default Mixin.create({
       async: 'async' in prop ? !!prop.async : false,
       readonly: 'readonly' in prop ? !!prop.readonly : false,
       initialValue: 'value' in prop ? result(prop, 'value') : null,
-      validate: prop.validate || null
+      validate: prop.validate || null,
+      ordered: prop.ordered || false
     };
   },
 
@@ -271,8 +272,13 @@ export default Mixin.create({
     const initialValue = this._getInitialPropertyValue(propertyName);
     const normalizedValue = normalizeValueForDirtyComparison(value);
     const normalizedInitialValue = normalizeValueForDirtyComparison(initialValue, isArray(normalizedValue));
+    const takeOrderIntoAccount = this.properties[propertyName].ordered;
 
-    return !areTwoValuesEqual(normalizedValue, normalizedInitialValue);
+    const opts = {
+      takeOrderIntoAccount
+    };
+
+    return !areTwoValuesEqual(normalizedValue, normalizedInitialValue, opts);
   },
 
   _updateIsDirty() {

--- a/addon/utils/dirty-comparison.js
+++ b/addon/utils/dirty-comparison.js
@@ -16,7 +16,9 @@ function normalizeValueForDirtyComparison(val, isValArray) {
   return normalizedVal;
 }
 
-function areTwoValuesEqual(a, b) {
+function areTwoValuesEqual(a, b, opts = {}) {
+  const { takeOrderIntoAccount } = opts;
+
   if (a === b) {
     return true;
   }
@@ -27,7 +29,9 @@ function areTwoValuesEqual(a, b) {
 
   if (isArray(a) && isArray(b) && a.length === b.length) {
     for (let i = 0; i < a.length; i += 1) {
-      if (a[i] !== b[i]) {
+      if (takeOrderIntoAccount && a[i] !== b[i]) {
+        return false;
+      } else if (!takeOrderIntoAccount && b.indexOf(a[i]) === -1) {
         return false;
       }
     }

--- a/tests/stubs/form.js
+++ b/tests/stubs/form.js
@@ -30,6 +30,13 @@ const baseFormObjectClassProps = {
     },
     'test3': {
       async: true
+    },
+    'testArray': {
+      value: [1, 2, 3]
+    },
+    'orderedTestArray': {
+      value: [1, 2, 3],
+      ordered: true
     }
   },
 

--- a/tests/unit/forms/base-form-test.js
+++ b/tests/unit/forms/base-form-test.js
@@ -254,3 +254,36 @@ test('it should enable removing properties dynamically', function(assert) {
   assert.equal(this.form.get('test'), void 0);
   assert.equal('test' in this.form.get('properties'), false);
 });
+
+test('it shouldn\'t be dirty after changing an array with the one with the same elements', function(assert) {
+  assert.equal(this.form.get('isDirty'), false);
+
+  const newArray = [].concat(this.form.get('testArray'));
+  this.form.set('testArray', newArray);
+
+  assert.equal(this.form.get('isDirty'), false);
+});
+
+test('it shouldn\'t be dirty after changing order of elements in an array', function(assert) {
+  assert.equal(this.form.get('isDirty'), false);
+
+  const newArray = [].concat(this.form.get('testArray'));
+  const el1 = newArray[1];
+  newArray[1] = newArray[0];
+  newArray[0] = el1;
+  this.form.set('testArray', newArray);
+
+  assert.equal(this.form.get('isDirty'), false);
+});
+
+test('it should be dirty after changing order of elements in an array if property is set as ordered', function(assert) {
+  assert.equal(this.form.get('isDirty'), false);
+
+  const newArray = [].concat(this.form.get('orderedTestArray'));
+  const el1 = newArray[1];
+  newArray[1] = newArray[0];
+  newArray[0] = el1;
+  this.form.set('orderedTestArray', newArray);
+
+  assert.equal(this.form.get('isDirty'), true);
+});


### PR DESCRIPTION
Added `ordered` option to form object property.
In case when`ordered=false` (that's default), array property won't be dirty if the "new value" is the same as the old one but with different order of elements.